### PR TITLE
Fix version for docker image

### DIFF
--- a/tools/version.sh
+++ b/tools/version.sh
@@ -22,7 +22,7 @@ make_version() {
   BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}  # Branch or pr or tag
   TAG=$( [[ $GITHUB_REF == refs/tags/* ]] && echo "${GITHUB_REF##refs/tags/}" || echo "" )
 
-  git fetch --tags
+  git fetch --tags --force
   git fetch --prune --unshallow || true
 
   LAST_RELEASE=$(get_last_release "$GIT_SHA")
@@ -75,12 +75,7 @@ make_version() {
 get_last_release() {
   GIT_SHA="$1"
 
-  git config --global --add safe.directory /github/workspace
-
-  git fetch --tags
-  git fetch --prune --unshallow || true
-
-  LAST_RELEASE=$(git tag --list --merged "$GIT_SHA" --sort=-version:refname "[0-9]*.[0-9]*.[0-9]*" | head -n 1)
+  LAST_RELEASE=$(git tag --list --merged "$GIT_SHA" --sort=-v:refname | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1)
 
   echo "$LAST_RELEASE"
 }


### PR DESCRIPTION
This repo uses old version of the function whitch gets the latest base version from tags. I updated the function get_last_release from template-python.
I can not test it because test does not pass. But I test it in template-python.