### PR TITLE
[docs] knowledge graph specification update v2

### DIFF
--- a/docs/0002-knowledge-graph-and-telemetry-specification-v2.md
+++ b/docs/0002-knowledge-graph-and-telemetry-specification-v2.md
@@ -47,7 +47,7 @@ Example with a Counter and cpu usage:
 
 - Instant query below returns the number of cores consumed by a pod for last sampling interval (~2 minutes):
 
-```json
+```promql
 sum (
 	rate(
 		container_cpu_usage_seconds_total{pod="kube-flannel-ds-7wjqv"}[2m]
@@ -57,7 +57,7 @@ sum (
 
 - Total number of core-seconds consumed by a pod for a large window interval, e.g. 1 hour.
 
-```json
+```promql
 
 sum (
 	increase(
@@ -69,7 +69,7 @@ sum (
 
 - Average number of core-seconds consumed by a pod during a large window interval, e.g. 1 hour.
 
-```json
+```promql
 
 sum (
 	rate(

--- a/docs/0002-knowledge-graph-and-telemetry-specification-v2.md
+++ b/docs/0002-knowledge-graph-and-telemetry-specification-v2.md
@@ -1,0 +1,124 @@
+# Knowledge Graph and Telemetry specification
+
+# Amendments
+
+| Date | Amendments |
+| --- | --- |
+| 13 may 2024 | - TradeOff Service API Response for Worker Node is adjusted<br/>- TradeOffService API Response for Workload is adjusted<br/>- Metric “Node energy consumption” for node is changed into “Node Energy Available” which is calculated as benchmarked node energy - consumed node energy.<br/>- Metric “Energy Used” for workload is added<br/>- Refined PromQL query examples for workload cpu usage |
+
+# Worker Node
+
+Terminology:
+
+- Capacity - the maximum allocatable units of resource on the kubernetes worker node.
+- Energy consumption: converting “<metric>_joules_total” (Counter) to milliwatts.
+
+    Average using window of 5 minutes (300 seconds):
+
+    - irate(kepler_node_platform_joules_total[300s]) / 300 = watts
+    - irate(kepler_node_platform_joules_total[300s]) *1000 / 300 = milliwatts
+
+| Metric | Source | Synthetic Data Generator | Knowledge graph, value of "glc:hasDescription" attribute of glc:Measurement | Tradeoff Service API Response, (JsonPath) |
+| --- | --- | --- | --- | --- |
+| Node energy index, milliwatt | Node resource:<br/>$.metadata.annotations.['glaciation-project.eu/metric/node-energy-index'] |  | node-energy-index | $.worker_nodes.resources.energy_index.max |
+| Node CPU capacity max, cores | Node resource: <br/> $.status.allocatable.cpu | WN_CPU_MAX_CAPACITY | cpu-capacity-max | $.worker_nodes.resources.cpu.max |
+| Node memory capacity max, Mb | Node resource: <br/> $.status.allocatable.memory | WN_MEM_MAX_CAPACITY | ram-capacity-max | $.worker_nodes.resources.memory.max |
+| Node gpu capacity max, Flops | Not available yet | WN_GPU_MAX_CAPACITY | gpu-capacity-max | $.worker_nodes.resources.gpu.max |
+| Node Storage capacity max (ephemeral storage), GB | TBD | WN_STR_MAX_CAPACITY | storage-capacity-max | $.worker_nodes.resources.storage.max |
+| Node network capacity max, GB per second | Not available yet | WN_NET_MAX_CAPACITY | network-bandwidth-max | $.worker_nodes.resource.network.max |
+| Node energy available, joules | Source: kepler<br/>node_energy_index - kepler_node_platform_joules_total{node=”glaciation-testm1w5-worker01”} | ENERGY_CONSUMPTION_MIN<br/> ENERGY_CONSUMPTION_MAX<br/>ENERGY_CONSUMPTION_MEDIAN<br/>ENERGY_CONSUMPTION_MEAN | node-energy-available | $.worker_nodes.resources.energy_index.available |
+| Node CPU available, core seconds | Source: node exporter<br/>sum(rate(node_cpu_seconds_total{mode="idle", node="glaciation-testm1w5-worker01"}[5m])) | WN_CPU_AVAILABLE | cpu-capacity-available | $.worker_nodes.resources.cpu.available |
+| Node Memory available, Mb | Source: node exporter<br/>node_memory_MemFree_bytes{instance="glaciation-testm1w5-worker01", app_kubernetes_io_component="metrics"} | WN_MEM_AVAILABLE  | ram-capacity-available | $.worker_nodes.resources.memory.available |
+| Node GPU available, flops | Not available yet | WN_GPU_AVAILABLE | gpu-capacity-available | $.worker_nodes.resources.gpu.available |
+| Node Storage available (PVC), Mb | Kubernetes metric:<br/>kubelet_volume_stats_available_bytes{instance="glaciation-testm1w5-worker01"}/ (1024 * 1024) | WN_STR_AVAILABLE | storage-capacity-available | $.worker_nodes.resources.storage.available |
+| Network Storage available (ephemeral), Mb | cAdvisor metric:<br/>container_fs_usage_bytes{instance="glaciation-testm1w5-worker01"}/ (1024 * 1024) | WN_STR_AVAILABLE | storage-capacity-available | $.worker_nodes.resources.storage.available |
+| Node Network available, Mb | TBD  | WN_NET_AVAILABLE | network-bandwidth-available | $.worker_nodes.resources.network.available |
+
+
+# Workload
+
+Terminology and interpretation:
+
+- Used - how much resource units is consumed (usage in terms of kubernetes - cAdvisor source)
+- Demanded - How much of resource units a user requests for a pod (”requests” in terms of kubernetes)
+- Allocated - How much of a resources is maximally allowed for a pod (limits in terms of kubernetes, It can also be configured on the level of cluster. To be researched)
+
+Example with a Counter and cpu usage:
+
+- Instant query below returns the number of cores consumed by a pod for last sampling interval (~2 minutes):
+
+```json
+sum (
+	rate(
+		container_cpu_usage_seconds_total{pod="kube-flannel-ds-7wjqv"}[2m]
+	)
+)
+```
+
+- Total number of core-seconds consumed by a pod for a large window interval, e.g. 1 hour.
+
+```json
+
+sum (
+	increase(
+		container_cpu_usage_seconds_total{pod="kube-flannel-ds-7wjqv"}[1h]
+	)
+)
+
+```
+
+- Average number of core-seconds consumed by a pod during a large window interval, e.g. 1 hour.
+
+```json
+
+sum (
+	rate(
+		container_cpu_usage_seconds_total{pod="kube-flannel-ds-7wjqv"}[1h]
+	)
+)
+
+```
+
+| Metric description | Source (prometheus or k8s resource) | Synthetic Data Generator | Knowledge graph, value of "glc:hasDescription" attribute of glc:Measurement | Tradeoff Service |
+| --- | --- | --- | --- | --- |
+| Network received usage, Mb | cAdvisor:<br/>sum(rate(container_network_receive_bytes_total[2m])) by (pod) / (1024 * 1024) | WL_NET_REC_USG_AVG<br/>WL_NET_REC_USG_MED<br/>WL_NET_REC_USG_MAX<br/>WL_NET_REC_USG_MIN | network-received | $.workloads.resources.network.used |
+| Network transfer usage, Mbit per second | cAdvisor:<br/>sum(rate(container_network_transmit_bytes_total[2m])) by (pod) | WL_NET_TRN_USG_MIN<br/>WL_NET_TRN_USG_MAX<br/>WL_NET_TRN_USG_MED<br/>WL_NET_TRN_USG_AVG | network-transferred | $.workloads.resources.network.used |
+| Storage read usage, Mb per second | cAdvisor:<br/>sum(rate(container_fs_reads_bytes_total[2m])) by (pod,device) / (1024 * 1024) | WL_STR_RED_USG_AVG<br/>WL_STR_RED_USG_MAX<br/>WL_STR_RED_USG_MIN<br/>WL_STR_RED_USG_MED | storage-read | $.workloads.resources.storage.used |
+| Storage write usage, MB per second | cAdvisor:<br/>sum(rate(container_fs_writes_bytes_total[2m])) by (pod,device) | WL_STR_WRT_USG_MIN<br/>WL_STR_WRT_USG_MAX<br/>WL_STR_WRT_USG_MED<br/>WL_STR_WRT_USG_AVG | storage-write | $.workloads.resources.storage.used |
+| Cpu usage minimum, unit: cores seconds | cAdvisor:<br/>sum(rate(container_cpu_usage_seconds_total[2m])) by (pod) | WL_CPU_USG_MIN<br/>WL_CPU_USG_MAX<br/>WL_CPU_USG_MED<br/>WL_CPU_USG_AVG | cpu-used | $.workloads.resources.cpu.used |
+| Memory usage, Mb (and can be fractional) | cAdvisor:<br/>sum(container_memory_working_set_bytes) by (pod) /(1024*1024) | WL_MEM_USG_MIN<br/>WL_MEM_USG_MAX<br/>WL_MEM_USG_MED<br/>WL_MEM_USG_AVG | ram-used | $.workloads.resources.memory.used |
+| GPU usage, flops | Not available, device specific k8s plugin | WL_GPU_USG_MIN<br/>WL_GPU_USG_MAX<br/>WL_GPU_USG_MED<br/>WL_GPU_USG_AVG | gpu-used | $.workloads.resources.gpu.used |
+| Energy Used, milliwatt | Kepler<br/>sum (kepler_container_joules_total[2m]) by (pod_name) | ENERGY_CONSUMPTION_MIN<br/>ENERGY_CONSUMPTION_MAX<br/>ENERGY_CONSUMPTION_MED<br/>ENERGY_CONSUMPTION_AVG | energy-used | $.workloads.resources.energy_index.used |
+| CPU limit, cores | K8s Deployment Resource<br/>$.spec.containers[].resources.limits.cpu | WL_CPU_ALC | cpu-limits | $.workloads.resources.cpu.allocated |
+| GPU limit, flops | K8s Deployment Resource<br/>$.spec.metadata.annotations[name=”glaciation-project.eu/resource/limits/gpu”] | WL_GPU_ALC | gpu-limits | $.workloads.resources.gpu.allocated |
+| Network limit, megabyte | K8s Deployment Resource<br/>$.spec.metadata.annotations[name=”glaciation-project.eu/resource/limits/network”] | WL_NET_ALC | network-limits | $.workloads.resources.network.allocated |
+| Storage limit, gigabyte | K8s Deployment Resource<br/>$.spec.containers[].resources.limits.ephemeral-storage | WL_STR_ALC | storage-limits | $.workloads.resources.storage.allocated |
+| Memory limit, megabytes | K8s Deployment Resource<br/>$.spec.containers[name=”container-name”].resources.limits.memory | WL_MEM_ALC | memory-limits | $.workloads.resources.memory.allocated |
+| Energy limit, milliwatt | K8s Deployment Resource<br/>$.spec.metadata.annotations[name=”glaciation-project.eu/resource/limits/energy”] | WL_ENERGY_ALC | energy-limits | $.workloads.resources.energy_index.allocated |
+| CPU requests, cores | K8s Deployment Resource<br/>$.spec.containers[].resources.requests.cpu | WL_CPU_DEM | cpu-requests | $.workloads.resources.cpu.demanded |
+| Memory requests, Mb | K8s Deployment Resource<br/>$.spec.containers[name=”container-name”].resources.requests.memory | WL_MEM_DEM | ram-requests | $.workloads.resources.memory.demanded |
+| GPU requests, flops | K8s Deployment Resource<br/>$.spec.metadata.annotations[name=”glaciation-project.eu/resource/requests/gpu”] | WL_GPU_DEM | gpu-requests | $.workloads.resources.gpu.demanded |
+| Storage requests, GB | K8s Deployment Resource<br/>$.spec.containers[].resources.requests.ephemeral-storage | WL_STR_DEM | storage-requests | $.workloads.resources.storage.demanded |
+| Network requests, Mb | K8s Deployment Resource<br/>$.spec.metadata.annotations[name=”glaciation-project.eu/resource/requests/network”] | WL_NET_DEM | network-requests | $.workloads.resources.network.demanded |
+| Energy requests, milliwatts | K8s Deployment Resource<br/>$.spec.metadata.annotations[name=”glaciation-project.eu/resource/requests/energy”] | WL_ENERGY_DEM | energy-requests | $.workloads.resources.energy_index.demanded |
+
+# Sample K8S resources, Knowledge graphs and TradeOffService API
+
+ - Worker Node
+    - [K8s worker node](./0002-knowledge-graph-and-telemetry-specification-v2/workernode-k8s-node.yaml)
+    - [Worker node metadata graph](./0002-knowledge-graph-and-telemetry-specification-v2/workernode-metadata-graph.jsonld)
+    - [TradeOffService Node API](./0002-knowledge-graph-and-telemetry-specification-v2/workernode-tradeoff-service-api.json)
+
+- Workload
+    - [K8s Workload](./0002-knowledge-graph-and-telemetry-specification-v2/workload-k8s-deployment.yaml) (Deployment/ReplicaSet/Pod)
+    - [Workload metadata graph](./0002-knowledge-graph-and-telemetry-specification-v2/workload-metadata-graph.jsonld)
+    - [TradeOffService Workload API](./0002-knowledge-graph-and-telemetry-specification-v2/workload-tradeoff-service-api.json)
+
+## References:
+
+1. cAdvisor metrics [https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md](https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md)
+2. Kubernetes metrics [https://kubernetes.io/docs/reference/instrumentation/metrics/](https://kubernetes.io/docs/reference/instrumentation/metrics/)
+
+3. Allocatable Memory in kubernetes: [https://dev.to/ridaehamdani/understanding-allocatable-memory-and-cpu-in-kubernetes-nodes-4hbm#:~:text=In Kubernetes%2C allocatable resources refer,available CPU and memory resources](https://dev.to/ridaehamdani/understanding-allocatable-memory-and-cpu-in-kubernetes-nodes-4hbm#:~:text=In%20Kubernetes%2C%20allocatable%20resources%20refer,available%20CPU%20and%20memory%20resources)
+
+4. Prometheus metrics parsing [https://docs.influxdata.com/influxdb/v1/supported_protocols/prometheus/](https://docs.influxdata.com/influxdb/v1/supported_protocols/prometheus/)

--- a/docs/0002-knowledge-graph-and-telemetry-specification-v2/workernode-k8s-node.yaml
+++ b/docs/0002-knowledge-graph-and-telemetry-specification-v2/workernode-k8s-node.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    glaciation-project.eu/metric/node-energy-index: '1000'
+    flannel.alpha.coreos.com/kube-subnet-manager: 'true'
+    flannel.alpha.coreos.com/public-ip: 10.14.1.151
+    kubeadm.alpha.kubernetes.io/cri-socket: unix:///var/run/containerd/containerd.sock
+    node.alpha.kubernetes.io/ttl: '0'
+    volumes.kubernetes.io/controller-managed-attach-detach: 'true'
+  creationTimestamp: '2024-02-13T14:05:06Z'
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: glaciation-test-worker01
+    kubernetes.io/os: linux
+  name: glaciation-test-worker01
+  resourceVersion: '2219223'
+  uid: bdbde1cb-8a2d-4907-af95-b6834c29a9bf
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+status:
+  addresses:
+  - address: 10.14.1.151
+    type: InternalIP
+  - address: glaciation-test-worker01
+    type: Hostname
+  allocatable:
+    cpu: '4'
+    ephemeral-storage: '47266578354'
+    hugepages-1Gi: '0'
+    hugepages-2Mi: '0'
+    memory: 16283152Ki
+    pods: '110'
+  capacity:
+    cpu: '4'
+    ephemeral-storage: 51287520Ki
+    hugepages-1Gi: '0'
+    hugepages-2Mi: '0'
+    memory: 16385552Ki
+    pods: '110'
+  conditions:
+  - lastHeartbeatTime: '2024-02-13T14:05:38Z'
+    lastTransitionTime: '2024-02-13T14:05:38Z'
+    message: Flannel is running on this node
+    reason: FlannelIsUp
+    status: 'False'
+    type: NetworkUnavailable
+  - lastHeartbeatTime: '2024-02-27T10:36:23Z'
+    lastTransitionTime: '2024-02-23T06:11:02Z'
+    message: kubelet has sufficient memory available
+    reason: KubeletHasSufficientMemory
+    status: 'False'
+    type: MemoryPressure
+  daemonEndpoints:
+    kubeletEndpoint:
+      Port: 10250
+  images:
+  - names:
+    - quay.io/cephcsi/cephcsi@sha256:5dd50ad6f3f9a1e8c8186fde0048ea241f056ca755acbeab42f5ebf723313e9c
+    - quay.io/cephcsi/cephcsi:v3.10.1
+    sizeBytes: 746084802
+  nodeInfo:
+    architecture: amd64
+    bootID: d6dd4518-eff0-416d-a6aa-f1cec097e5eb
+    containerRuntimeVersion: containerd://1.6.18
+    kernelVersion: 5.15.0-67-generic
+    kubeProxyVersion: v1.26.3
+    kubeletVersion: v1.26.3
+    machineID: b057678a09844d90b1596c053836ab36
+    operatingSystem: linux
+    osImage: Ubuntu 22.04.2 LTS
+    systemUUID: dd000942-702b-b9ab-71a7-ff172d755dff

--- a/docs/0002-knowledge-graph-and-telemetry-specification-v2/workernode-metadata-graph.jsonld
+++ b/docs/0002-knowledge-graph-and-telemetry-specification-v2/workernode-metadata-graph.jsonld
@@ -1,0 +1,330 @@
+{
+    "@context": {
+        "glc": "https://glaciation-heu.github.io/models/reference_model.turtle",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "cluster": "https://10.1.14.160:6443/"
+    },
+    "@graph": [
+        {
+            "@type": "glc:Resource",
+            "glc:hasID": "cluster:/apis/nodes/v1/wn1",
+            "glc:hasSubResource": {
+                "@set": [
+                    {
+                        "@type": "glc:Resource",
+                        "glc:hasID": "cluster:/apis/nodes/v1/wn1.CPU",
+                        "glc:hasDescription": "CPU",
+                        "glc:hasMeasurement": {
+                            "@set": [
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.CPU.CapacityMax",
+                                    "glc:hasDescription": "cpu-capacity-max",
+                                    "glc:relatesToMeasurementProperty": "CPU.Capacity",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 4,
+                                    "glc:measuredIn": "CPU.cores"
+                                },
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.CPU.CapacityAvailable",
+                                    "glc:hasDescription": "cpu-capacity-available",
+                                    "glc:relatesToMeasurementProperty": "CPU.Available",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 4,
+                                    "glc:measuredIn": "CPU.cores"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "@type": "glc:Resource",
+                        "glc:hasID": "cluster:/apis/nodes/v1/wn1.GPU",
+                        "glc:hasDescription": "GPU",
+                        "glc:hasMeasurement": {
+                            "@set": [
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.GPU.Capacity.Max",
+                                    "glc:hasDescription": "gpu-capacity-max",
+                                    "glc:relatesToMeasurementProperty": "GPU.Capacity",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 1,
+                                    "glc:measuredIn": "GPU.flops"
+                                },
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.GPU.CapacityAvailable",
+                                    "glc:hasDescription": "gpu-capacity-available",
+                                    "glc:relatesToMeasurementProperty": "GPU.Available",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 1,
+                                    "glc:measuredIn": "GPU.flops"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "@type": "glc:Resource",
+                        "glc:hasID": "cluster:/apis/nodes/v1/wn1.RAM",
+                        "glc:hasDescription": "RAM",
+                        "glc:hasMeasurement": {
+                            "@set": [
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.RAM.CapacityMax",
+                                    "glc:hasDescription": "ram-capacity-max",
+                                    "glc:relatesToMeasurementProperty": "RAM.Capacity",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 16,
+                                    "glc:measuredIn": "RAM.mb"
+                                },
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.RAM.Available",
+                                    "glc:hasDescription": "ram-capacity-available",
+                                    "glc:relatesToMeasurementProperty": "RAM.Available",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 16,
+                                    "glc:measuredIn": "RAM.mb"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "@id": "cluster:/apis/nodes/v1/wn1.Storage",
+                        "@type": "glc:Resource",
+                        "glc:hasDescription": "Storage",
+                        "glc:hasMeasurement": {
+                            "@set": [
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.Storage.CapacityMax",
+                                    "glc:hasDescription": "storage-capacity-max",
+                                    "glc:relatesToMeasurementProperty": "Storage.Capacity",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 64,
+                                    "glc:measuredIn": "Storage.gb"
+                                },
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.Storage.Available",
+                                    "glc:hasDescription": "storage-capacity-available",
+                                    "glc:relatesToMeasurementProperty": "Storage.Available",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 64,
+                                    "glc:measuredIn": "Storage.gb"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "@id": "cluster:/apis/nodes/v1/wn1.Network",
+                        "@type": "glc:Resource",
+                        "glc:hasDescription": "Network",
+                        "glc:hasMeasurement": {
+                            "@set": [
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.Network.BandwidthMax",
+                                    "glc:hasDescription": "network-bandwidth-max",
+                                    "glc:relatesToMeasurementProperty": "Network.Bandwidth",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 10,
+                                    "glc:measuredIn": "Network.Bandwidth"
+                                },
+                                {
+                                    "@type": "glc:Measurement",
+                                    "glc:hasID": "cluster:/apis/nodes/v1/wn1.Network.BandwidthAvailable",
+                                    "glc:hasDescription": "network-bandwidth-available",
+                                    "glc:relatesToMeasurementProperty": "Network.Bandwidth",
+                                    "glc:hasTimestamp": 16034236464,
+                                    "glc:hasValue": 10,
+                                    "glc:measuredIn": "Network.Bandwidth"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "glc:hasMeasurement": {
+                "@set": [
+                    {
+                        "@type": "glc:Measurement",
+                        "glc:hasID": "cluster:/apis/nodes/v1/wn1.energy-index",
+                        "glc:hasDescription": "node-energy-index",
+                        "glc:relatesToMeasurementProperty": "EnergyIndex",
+                        "glc:hasValue": 1000,
+                        "glc:measuredIn": "Energy.milliwatt"
+                    },
+                    {
+                        "@type": "glc:Measurement",
+                        "glc:hasID": "cluster:/apis/nodes/v1/wn1.energy-consumption.16034236464",
+                        "glc:hasDescription": "node-energy-available",
+                        "glc:relatesToMeasurementProperty": "Energy",
+                        "glc:hasTimestamp": 16034236464,
+                        "glc:hasValue": 1000,
+                        "glc:measuredIn": "Energy.milliwatt"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "CPU.coreseconds",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasID": "CPU.coreseconds",
+            "glc:hasDescription": "CPU in coreseconds"
+        },
+        {
+            "@id": "GPU.flops",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasID": "GPU.flops",
+            "glc:hasDescription": "GPU flops"
+        },
+        {
+            "@id": "RAM.mb",
+            "gls:hasID": "RAM.mb",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasDescription": "RAM in megabytes"
+        },
+        {
+            "@id": "Storage.gb",
+            "glc:hasID": "Storage.gb",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasDescription": "Storage in gigabytes"
+        },
+        {
+            "@id": "Network.mb",
+            "glc:hasID": "Network.mb",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasDescription": "Network in megabytes"
+        },
+        {
+            "@id": "Energy.milliwatt",
+            "glc:hasID": "Energy.milliwatt",
+            "@type": "glc:MeasurementUnit"
+        },
+
+        {
+            "@id": "CPU.Capacity",
+            "glc:hasID": "CPU.Capacity",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "CPU Capacity of a node"
+        },
+        {
+            "@id": "CPU.Available",
+            "glc:hasID": "CPU.Available",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Available CPU of a node"
+        },
+
+        {
+            "@id": "GPU.Capacity",
+            "glc:hasID": "GPU.Capacity",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "GPU Capacity of a node"
+        },
+        {
+            "@id": "GPU.Available",
+            "glc:hasID": "GPU.Available",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Available GPU of a node"
+        },
+
+        {
+            "@id": "RAM.Capacity",
+            "glc:hasID": "RAM.Capacity",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "RAM Capacity on node"
+        },
+        {
+            "@id": "RAM.Available",
+            "glc:hasID": "RAM.Available",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Available RAM on node"
+        },
+
+        {
+            "@id": "Storage.Capacity",
+            "glc:hasID": "Storage.Capacity",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Storage capacity on a node"
+        },
+        {
+            "@id": "Storage.Available",
+            "glc:hasID": "Storage.Available",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Available storage on a node"
+        },
+
+        {
+            "@id": "Network.Bandwidth",
+            "glc:hasID": "Network.Bandwidth",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Network bandwidth of a node"
+        },
+
+        {
+            "@id": "Energy",
+            "glc:hasID": "Energy",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Energy consumed by a cluster, a node or a pod"
+        },
+        {
+            "@id": "EnergyIndex",
+            "glc:hasID": "EnergyIndex",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Energy index"
+        },
+
+        {
+            "@id": "Kepler",
+            "@type": "glc:MeasuringResource",
+            "glc:hasID": "Kepler",
+            "glc:hasDescription": "Kepler metrics https://sustainable-computing.io/",
+            "glc:makes": [
+                "cluster:/apis/nodes/v1/wn1.energy-consumption.16034236464"
+            ]
+        },
+        {
+            "@id": "NodeEnergyBenchmark",
+            "@type": "glc:MeasuringResource",
+            "glc:hasID": "NodeEnergyBenchmark",
+            "glc:makes": [
+                "cluster:/apis/nodes/v1/wn1.energy-index"
+            ]
+        },
+        {
+            "@id": "cAdvisor",
+            "@type": "glc:MeasuringResource",
+            "glc:hasID": "cAdvisor",
+            "glc:hasDescription": "cAdvisor metrics https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md",
+            "glc:makes": [
+                "cluster:/apis/nodes/v1/wn1.Storage.Available"
+            ]
+        },
+        {
+            "@id": "NodeExporter",
+            "@type": "glc:MeasuringResource",
+            "glc:hasID": "NodeExporter",
+            "glc:hasDescription": "Node exporter metrics https://github.com/prometheus/node_exporter",
+            "glc:makes": [
+                "cluster:/apis/nodes/v1/wn1.CPU.CapacityAvailable",
+                "cluster:/apis/nodes/v1/wn1.RAM.Available"
+            ]
+        },
+        {
+            "@id": "Kubernetes",
+            "@type": "glc:MeasuringResource",
+            "glc:hasID": "Kubernetes",
+            "glc:hasDescription": "Kubernetes allocated resources",
+            "glc:makes": [
+                "cluster:/apis/nodes/v1/wn1.CPU.CapacityMax",
+                "cluster:/apis/nodes/v1/wn1.GPU.Capacity.Max",
+                "cluster:/apis/nodes/v1/wn1.RAM.CapacityMax",
+                "cluster:/apis/nodes/v1/wn1.Storage.CapacityMax"
+            ]
+        }
+
+    ]
+}

--- a/docs/0002-knowledge-graph-and-telemetry-specification-v2/workernode-tradeoff-service-api.json
+++ b/docs/0002-knowledge-graph-and-telemetry-specification-v2/workernode-tradeoff-service-api.json
@@ -1,0 +1,40 @@
+{
+    "cluster_id": "cluster1",
+    "worker_nodes": [
+        {
+            "node_id": "cluster:/apis/nodes/v1/wn1",
+            "resources": {
+                "cpu": {
+                    "max": 8,
+                    "available": 4,
+                    "unit": "cores"
+                },
+                "gpu": {
+                    "max": 2,
+                    "available": 1,
+                    "unit": "units"
+                },
+                "memory": {
+                    "max": 16,
+                    "available": 8,
+                    "unit": "GB"
+                },
+                "storage": {
+                    "max": 512,
+                    "available": 128,
+                    "unit": "GB"
+                },
+                "network": {
+                    "max": 256,
+                    "available": 128,
+                    "unit": "Mbps"
+                },
+                "energy_index": {
+                    "max": 85000,
+                    "available": 30000,
+                    "unit": "milliwatt"
+                }
+            }
+        }
+    ]
+}

--- a/docs/0002-knowledge-graph-and-telemetry-specification-v2/workload-k8s-deployment.yaml
+++ b/docs/0002-knowledge-graph-and-telemetry-specification-v2/workload-k8s-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      annotations:
+        glaciation-project.eu/resource/limits/energy: "100"
+        glaciation-project.eu/resource/limits/network: "1010"
+        glaciation-project.eu/resource/limits/gpu: "101"
+        glaciation-project.eu/resource/requests/energy: "100"
+        glaciation-project.eu/resource/requests/network: "1010"
+        glaciation-project.eu/resource/requests/gpu: "101"
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+            ephemeral-storage: "2Gi"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+            ephemeral-storage: "3Gi"
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: ephemeral
+          mountPath: "/tmp"

--- a/docs/0002-knowledge-graph-and-telemetry-specification-v2/workload-metadata-graph.jsonld
+++ b/docs/0002-knowledge-graph-and-telemetry-specification-v2/workload-metadata-graph.jsonld
@@ -1,0 +1,401 @@
+{
+    "@context": {
+        "glc": "https://glaciation-heu.github.io/models/reference_model.turtle",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "cluster": "https://10.1.14.160:6443/"
+    },
+    "@graph": [
+        {
+            "@id": "cluster:/apis/deployment/v1/deployment1",
+            "glc:hasDescription": "deployment-name",
+            "@type": "glc:AssignedTask",
+            "glc:produces": [
+                "cluster:/apis/replicaset/v1/replicaset1"
+            ],
+            "glc:hasConstraint": {
+                "@set": [
+                    {
+                        "@type": "glc:SoftConstraint",
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.requests.cpu",
+                        "glc:hasDescription": "cpu-requests",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption",
+                            "Aspect.Productivity"
+                        ],
+                        "value": 1,
+                        "glc:measuredIn": "CPU.cores"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.requests.ram",
+                        "glc:hasDescription": "ram-requests",
+                        "@type": "glc:SoftConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 1,
+                        "glc:measuredIn": "RAM.mb"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.requests.storage",
+                        "glc:hasDescription": "storage-requests",
+                        "@type": "glc:SoftConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 25,
+                        "glc:measuredIn": "Storage.mb"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.requests.gpu",
+                        "glc:hasDescription": "gpu-requests",
+                        "@type": "glc:SoftConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption",
+                            "Aspect.Productivity"
+                        ],
+                        "value": 100,
+                        "glc:measuredIn": "GPU.flops"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.requests.network",
+                        "glc:hasDescription": "network-requests",
+                        "@type": "glc:SoftConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 100,
+                        "glc:measuredIn": "Network.mb"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.requests.energy",
+                        "glc:hasDescription": "energy-requests",
+                        "@type": "glc:SoftConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 100,
+                        "glc:measuredIn": "Energy.milliwatt"
+                    },
+
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.limits.cpu",
+                        "glc:hasDescription": "cpu-limits",
+                        "@type": "glc:HardConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 100,
+                        "glc:measuredIn": "CPU.cores"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.limits.gpu",
+                        "glc:hasDescription": "gpu-limits",
+                        "@type": "glc:HardConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 100,
+                        "glc:measuredIn": "GPU.flops"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.limits.ram",
+                        "glc:hasDescription": "ram-limits",
+                        "@type": "glc:HardConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 100,
+                        "glc:measuredIn": "RAM.mb"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.limits.storage",
+                        "glc:hasDescription": "storage-limits",
+                        "@type": "glc:HardConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 100,
+                        "glc:measuredIn": "Storage.gb"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.limits.network",
+                        "glc:hasDescription": "network-limits",
+                        "@type": "glc:HardConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 100,
+                        "glc:measuredIn": "Network.mb"
+                    },
+                    {
+                        "glc:hasId": "cluster:/apis/deployment/v1/deployment1.limits.energy",
+                        "glc:hasDescription": "energy-limits",
+                        "@type": "glc:HardConstraint",
+                        "glc:hasAspect": [
+                            "Aspect.PowerConsumption"
+                        ],
+                        "value": 100,
+                        "glc:measuredIn": "Energy.milliwatt"
+                    }
+                ]
+            },
+            "glc:hasRealizedMeasurement": {
+                "@set": [
+                    {
+                        "@id": "cluster:/apis/deployment/v1/deployment1.energy-index",
+                        "@type": "glc:Measurement",
+                        "glc:hasDescription": "energy-index",
+                        "glc:relatesToMeasurementProperty": "EnergyIndex",
+                        "glc:hasTimestamp": 16034236464,
+                        "glc:hasValue": 0.100500,
+                        "glc:measuredIn": "Energy.milliwatt"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "cluster:/apis/replicaset/v1/replicaset1",
+            "@type": "glc:AssignedTask",
+            "glc:produces": [
+                "cluster:/apis/pods/v1/pod1",
+                "cluster:/apis/pods/v1/pod2"
+            ]
+        },
+        {
+            "@id": "cluster:/apis/pods/v1/pod1",
+            "@type": "glc:Resource",
+            "glc:hasID": "cluster:/apis/pods/v1/pod1",
+            "glc:status": {
+                "@type": "glc:Status",
+                "glc:startTime": "2024-03-10T10:25:00",
+                "glc:endTime": "2024-03-10T13:25:00",
+                "glc:hasDescription": "Terminated"
+            },
+            "glc:hasSubResource": {
+                "@set": [
+                    {
+                        "@type": "glc:Resource",
+                        "glc:hasID": "cluster:/apis/pods/v1/pod1.container1",
+                        "glc:hasDescription": "container-name1"
+                    },
+                    {
+                        "@type": "glc:Resource",
+                        "glc:hasID": "cluster:/apis/pods/v1/pod1.container2",
+                        "glc:hasDescription": "container-name2"
+                    }
+                ]
+            },
+            "glc:hasMeasurement": {
+                "@set": [
+                    {
+                        "@type": "glc:Measurement",
+                        "glc:hasID": "cluster:/apis/pods/v1/pod1.Measurement.CPU.Used.16034236464",
+                        "glc:relatesToMeasurementProperty": "CPU.Used",
+                        "glc:hasDescription": "cpu-used",
+                        "glc:hasTimestamp": 16034236464,
+                        "glc:hasValue": 0.3,
+                        "glc:measuredIn": "CPU.coreseconds"
+                    },
+                    {
+                        "@type": "glc:Measurement",
+                        "glc:hasID": "cluster:/apis/pods/v1/pod1.Measurement.GPU.Used.16034236464",
+                        "glc:relatesToMeasurementProperty": "GPU.Used",
+                        "glc:hasDescription": "gpu-used",
+                        "glc:hasTimestamp": 16034236464,
+                        "glc:hasValue": 0.3,
+                        "glc:measuredIn": "GPU.flops"
+                    },
+                    {
+                        "@type": "glc:Measurement",
+                        "glc:hasID": "cluster:/apis/pods/v1/pod1.Measurement.RAM.Used.16034236464",
+                        "glc:relatesToMeasurementProperty": "RAM.Used",
+                        "glc:hasDescription": "ram-used",
+                        "glc:hasTimestamp": 16034236464,
+                        "glc:hasValue": 0.3,
+                        "glc:measuredIn": "RAM.mb"
+                    },
+                    {
+                        "@type": "glc:Measurement",
+                        "glc:hasID": "cluster:/apis/pods/v1/pod1.Measurement.Storage.Read.16034236464",
+                        "glc:hasDescription": "storage-read",
+                        "glc:relatesToMeasurementProperty": "Storage.Read",
+                        "glc:hasTimestamp": 16034236464,
+                        "glc:hasValue": 0.3,
+                        "glc:measuredIn": "Storage.gb"
+                    },
+                    {
+                        "@type": "glc:Measurement",
+                        "glc:hasID": "cluster:/apis/pods/v1/pod1.Measurement.Storage.Write.16034236464",
+                        "glc:hasDescription": "storage-write",
+                        "glc:relatesToMeasurementProperty": "Storage.Write",
+                        "glc:hasTimestamp": 16034236464,
+                        "glc:hasValue": 0.3,
+                        "glc:measuredIn": "Storage.gb"
+                    },
+                    {
+                        "@type": "glc:Measurement",
+                        "glc:hasID": "cluster:/apis/pods/v1/pod1.Measurement.Network.Used.16034236464",
+                        "glc:relatesToMeasurementProperty": "Network.Used",
+                        "glc:hasDescription": "network-used",
+                        "glc:hasTimestamp": 16034236464,
+                        "glc:hasValue": 0.3,
+                        "glc:measuredIn": "Network.mb"
+                    },
+                    {
+                        "@type": "glc:Measurement",
+                        "glc:hasID": "cluster:/apis/pods/v1/pod1.Energy.Measurement.Used.16034236464",
+                        "glc:hasDescription": "energy-used",
+                        "glc:relatesToMeasurementProperty": "Energy",
+                        "glc:hasTimestamp": 16034236464,
+                        "glc:hasValue": 1000,
+                        "glc:measuredIn": "Energy.milliwatt"
+                    }
+                ]
+            }
+        },
+
+        {
+            "@id": "CPU.coreseconds",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasID": "CPU.coreseconds",
+            "glc:hasDescription": "CPU in coresseconds"
+        },
+        {
+            "@id": "CPU.cores",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasID": "CPU.cores",
+            "glc:hasDescription": "CPU in cores"
+        },
+        {
+            "@id": "GPU.flops",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasID": "GPU.flops",
+            "glc:hasDescription": "GPU flops"
+        },
+        {
+            "@id": "RAM.mb",
+            "gls:hasID": "RAM.mb",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasDescription": "RAM in megabytes"
+        },
+        {
+            "@id": "Storage.gb",
+            "glc:hasID": "Storage.gb",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasDescription": "Storage in gigabytes"
+        },
+        {
+            "@id": "Network.mb",
+            "glc:hasID": "Network.mb",
+            "@type": "glc:MeasurementUnit",
+            "glc:hasDescription": "Network in megabytes"
+        },
+        {
+            "@id": "Energy.milliwatt",
+            "glc:hasID": "Energy.milliwatt",
+            "@type": "glc:MeasurementUnit"
+        },
+
+        {
+            "@id": "CPU.Used",
+            "glc:hasID": "CPU.Used",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "CPU used"
+        },
+        {
+            "@id": "GPU.Used",
+            "glc:hasID": "GPU.Used",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "GPU used"
+        },
+        {
+            "@id": "RAM.Used",
+            "glc:hasID": "RAM.Used",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "RAM used"
+        },
+        {
+            "@id": "Storage.Read",
+            "glc:hasID": "Storage.Read",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Storage read"
+        },
+        {
+            "@id": "Storage.Write",
+            "glc:hasID": "Storage.Write",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Storage write"
+        },
+        {
+            "@id": "Network.Used",
+            "glc:hasID": "Network.Used",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Network used"
+        },
+        {
+            "@id": "Energy",
+            "glc:hasID": "Energy",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Energy consumed by a cluster, a node or a pod"
+        },
+        {
+            "@id": "EnergyIndex",
+            "glc:hasID": "EnergyIndex",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasDescription": "Energy index"
+        },
+
+        {
+            "@id": "DefaultScheduler",
+            "glc:hasID": "DefaultScheduler",
+            "@type": "glc:Scheduler",
+            "glc:assigns": [
+                "cluster:/apis/deployment/v1/deployment1"
+            ]
+        },
+
+        {
+            "@id": "Aspect.PowerConsumption",
+            "@type": "glc:Aspect",
+            "glc:hasID": "Aspect.PowerConsumption"
+        },
+        {
+            "@id": "Aspect.Productivity",
+            "@type": "glc:Aspect",
+            "glc:hasID": "Aspect.Productivity"
+        },
+
+        {
+            "@id": "Kepler",
+            "@type": "glc:MeasuringResource",
+            "glc:hasID": "Kepler",
+            "glc:hasDescription": "Kepler metrics https://sustainable-computing.io/",
+            "glc:makes": [
+                "cluster:/apis/pods/v1/pod1.Energy.Measurement.Used.16034236464"
+            ]
+        },
+        {
+            "@id": "WorkloadEnergyBenchmark",
+            "@type": "glc:MeasuringResource",
+            "glc:hasID": "WorkloadEnergyBenchmark",
+            "glc:makes": [
+                "cluster:/apis/deployment/v1/deployment1.energy-index"
+            ]
+        },
+        {
+            "@id": "cAdvisor",
+            "@type": "glc:MeasuringResource",
+            "glc:hasID": "cAdvisor",
+            "glc:hasDescription": "cAdvisor metrics https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md",
+            "glc:makes": [
+                "cluster:/apis/pods/v1/pod1.Measurement.CPU.Used.16034236464",
+                "cluster:/apis/pods/v1/pod1.Measurement.GPU.Used.16034236464",
+                "cluster:/apis/pods/v1/pod1.Measurement.RAM.Used.16034236464",
+                "cluster:/apis/pods/v1/pod1.Measurement.Storage.Read.16034236464",
+                "cluster:/apis/pods/v1/pod1.Measurement.Storage.Write.16034236464",
+                "cluster:/apis/pods/v1/pod1.Measurement.Network.Used.16034236464"
+            ]
+        }
+
+    ]
+}

--- a/docs/0002-knowledge-graph-and-telemetry-specification-v2/workload-tradeoff-service-api.json
+++ b/docs/0002-knowledge-graph-and-telemetry-specification-v2/workload-tradeoff-service-api.json
@@ -1,0 +1,51 @@
+{
+    "cluster_id": "cluster1",
+    "workloads": [
+        {
+            "workload_id": "cluster:/apis/workloads/wl1",
+            "runs_on": {
+                "start_time": "2024-02-08 18:40:00",
+                "end_time": "2024-02-08 18:45:00",
+                "worker_node_id": "cluster:/apis/nodes/wnode1"
+            },
+            "resources": {
+                "cpu": {
+                    "unit": "cores",
+                    "demanded": 4,
+                    "allocated": 8,
+                    "used": 0.2
+                },
+                "gpu": {
+                    "unit": "flops",
+                    "demanded": 4,
+                    "allocated": 8,
+                    "used": 1.0
+                },
+                "memory": {
+                    "unit": "GB",
+                    "demanded": 4,
+                    "allocated": 8,
+                    "used": 1.2
+                },
+                "storage": {
+                    "unit": "GB",
+                    "demanded": 4,
+                    "allocated": 8,
+                    "used": 1.2
+                },
+                "network": {
+                    "unit": "MB",
+                    "demanded": 1.0,
+                    "allocated": 1.0,
+                    "used": 0.5
+                },
+                "energy_index": {
+                    "unit": "milliwatt",
+                    "demanded": 10,
+                    "allocated": 10,
+                    "used": 1.0
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- TradeOff Service API Response for Worker Node is adjusted
- TradeOffService API Response for Workload is adjusted
- Metric “Node energy consumption” for node is changed into “Node Energy Available” which is calculated as benchmarked node energy - consumed node energy.
- Metric “Energy Used” for workload is added
- Refined PromQL query examples for workload cpu usage