### PR TITLE
HHT-1417: integration testing fixes

### DIFF
--- a/app/core/__fixture__/snapshot/minimal/k8s_deployments.yaml
+++ b/app/core/__fixture__/snapshot/minimal/k8s_deployments.yaml
@@ -20,12 +20,10 @@
         labels:
           k8s-app: kube-dns
         annotations:
-          glaciation-project.eu/resource/limits/energy: '100'
-          glaciation-project.eu/resource/limits/network: '1010'
-          glaciation-project.eu/resource/limits/gpu: '101'
-          glaciation-project.eu/resource/requests/energy: '100'
-          glaciation-project.eu/resource/requests/network: '1010'
-          glaciation-project.eu/resource/requests/gpu: '101'
+          glaciation-project.eu/energy-capacity: '100'
+          glaciation-project.eu/network-capacity: '1010'
+          glaciation-project.eu/energy-allocated: '100'
+          glaciation-project.eu/network-allocated: '1010'
       spec:
         initContainers:
         - name: init-coredns
@@ -40,9 +38,11 @@
           resources:
             limits:
               memory: 170Mi
+              nvidia.com/gpu: 101
             requests:
               cpu: 100m
               memory: 70Mi
+              nvidia.com/gpu: 101
         - name: coredns-other
           resources:
             limits:

--- a/app/core/__fixture__/snapshot/minimal/k8s_nodes.yaml
+++ b/app/core/__fixture__/snapshot/minimal/k8s_nodes.yaml
@@ -4,7 +4,7 @@
     name: glaciation-test-master01
     uid: 1
     annotations:
-      glaciation-project.eu/metric/node-energy-index: '1001'
+      glaciation-project.eu/node-energy-index: '1001'
   spec:
   status:
     allocatable:

--- a/app/core/__fixture__/snapshot/multinode/k8s_deployments.yaml
+++ b/app/core/__fixture__/snapshot/multinode/k8s_deployments.yaml
@@ -19,12 +19,10 @@
         labels:
           k8s-app: kube-dns
         annotations:
-          glaciation-project.eu/resource/limits/energy: '100'
-          glaciation-project.eu/resource/limits/network: '1010'
-          glaciation-project.eu/resource/limits/gpu: '101'
-          glaciation-project.eu/resource/requests/energy: '100'
-          glaciation-project.eu/resource/requests/network: '1010'
-          glaciation-project.eu/resource/requests/gpu: '101'
+          glaciation-project.eu/energy-capacity: '100'
+          glaciation-project.eu/network-capacity: '1010'
+          glaciation-project.eu/energy-allocated: '100'
+          glaciation-project.eu/network-allocated: '1010'
       spec:
         initContainers:
         - name: init-coredns
@@ -39,9 +37,11 @@
           resources:
             limits:
               memory: 170Mi
+              nvidia.com/gpu: 101
             requests:
               cpu: 100m
               memory: 70Mi
+              nvidia.com/gpu: 101
         - name: coredns-other
           resources:
             limits:

--- a/app/core/__fixture__/snapshot/multinode/k8s_nodes.yaml
+++ b/app/core/__fixture__/snapshot/multinode/k8s_nodes.yaml
@@ -3,7 +3,7 @@
   metadata:
     name: glaciation-test-master01
     annotations:
-      glaciation-project.eu/metric/node-energy-index: '1001'
+      glaciation-project.eu/node-energy-index: '1001'
   spec:
   status:
     allocatable:
@@ -33,7 +33,7 @@
   metadata:
     name: glaciation-test-worker01
     annotations:
-      glaciation-project.eu/metric/node-energy-index: '1001'
+      glaciation-project.eu/node-energy-index: '1001'
   spec:
   status:
     allocatable:

--- a/app/transform/k8s/__fixture__/deployment.json
+++ b/app/transform/k8s/__fixture__/deployment.json
@@ -48,12 +48,10 @@
                     "k8s-app": "kube-dns"
                 },
                 "annotations": {
-                    "glaciation-project.eu/resource/limits/energy": "100",
-                    "glaciation-project.eu/resource/limits/network": "1010",
-                    "glaciation-project.eu/resource/limits/gpu": "101",
-                    "glaciation-project.eu/resource/requests/energy": "100",
-                    "glaciation-project.eu/resource/requests/network": "1010",
-                    "glaciation-project.eu/resource/requests/gpu": "101"
+                    "glaciation-project.eu/energy-capacity": "100",
+                    "glaciation-project.eu/network-capacity": "1010",
+                    "glaciation-project.eu/energy-allocated": "100",
+                    "glaciation-project.eu/network-allocated": "1010"
                 }
             },
             "spec": {
@@ -161,11 +159,13 @@
                         },
                         "resources": {
                             "limits": {
-                                "memory": "170Mi"
+                                "memory": "170Mi",
+                                "nvidia.com/gpu": 1
                             },
                             "requests": {
                                 "cpu": "100m",
-                                "memory": "70Mi"
+                                "memory": "70Mi",
+                                "nvidia.com/gpu": 1
                             }
                         },
                         "securityContext": {

--- a/app/transform/k8s/__fixture__/deployment.jsonld
+++ b/app/transform/k8s/__fixture__/deployment.jsonld
@@ -96,7 +96,7 @@
                         "@id": "cluster:coredns.GPU.Allocated",
                         "@type": "glc:SoftConstraint",
                         "glc:hasDescription": "GPU.Allocated",
-                        "glc:maxValue": 101.0,
+                        "glc:maxValue": 1.0,
                         "glc:hasAspect": {
                             "@id": "glc:Performance"
                         },
@@ -111,7 +111,7 @@
                         "@id": "cluster:coredns.GPU.Capacity",
                         "@type": "glc:HardConstraint",
                         "glc:hasDescription": "GPU.Capacity",
-                        "glc:maxValue": 101.0,
+                        "glc:maxValue": 1.0,
                         "glc:hasAspect": {
                             "@id": "glc:Performance"
                         },

--- a/app/transform/k8s/__fixture__/deployment.turtle
+++ b/app/transform/k8s/__fixture__/deployment.turtle
@@ -22,13 +22,13 @@ cluster:coredns.Energy.Capacity glc:hasID cluster:coredns.Energy.Capacity .
 cluster:coredns.Energy.Capacity glc:measuredIn glc:Milliwatt .
 cluster:coredns.GPU.Allocated rdf:type glc:SoftConstraint .
 cluster:coredns.GPU.Allocated glc:hasDescription "GPU.Allocated" .
-cluster:coredns.GPU.Allocated glc:maxValue 101.0^^<http://www.w3.org/2001/XMLSchema#integer> .
+cluster:coredns.GPU.Allocated glc:maxValue 1.0^^<http://www.w3.org/2001/XMLSchema#integer> .
 cluster:coredns.GPU.Allocated glc:hasAspect glc:Performance .
 cluster:coredns.GPU.Allocated glc:hasID cluster:coredns.GPU.Allocated .
 cluster:coredns.GPU.Allocated glc:measuredIn glc:Core .
 cluster:coredns.GPU.Capacity rdf:type glc:HardConstraint .
 cluster:coredns.GPU.Capacity glc:hasDescription "GPU.Capacity" .
-cluster:coredns.GPU.Capacity glc:maxValue 101.0^^<http://www.w3.org/2001/XMLSchema#integer> .
+cluster:coredns.GPU.Capacity glc:maxValue 1.0^^<http://www.w3.org/2001/XMLSchema#integer> .
 cluster:coredns.GPU.Capacity glc:hasAspect glc:Performance .
 cluster:coredns.GPU.Capacity glc:hasID cluster:coredns.GPU.Capacity .
 cluster:coredns.GPU.Capacity glc:measuredIn glc:Core .

--- a/app/transform/k8s/__fixture__/master_node.json
+++ b/app/transform/k8s/__fixture__/master_node.json
@@ -10,7 +10,7 @@
             "kubeadm.alpha.kubernetes.io/cri-socket": "unix:///var/run/containerd/containerd.sock",
             "node.alpha.kubernetes.io/ttl": "0",
             "volumes.kubernetes.io/controller-managed-attach-detach": "true",
-            "glaciation-project.eu/metric/node-energy-index": "1001"
+            "glaciation-project.eu/node-energy-index": "1001"
         },
         "creationTimestamp": "2024-02-13T13:50:36Z",
         "labels": {

--- a/app/transform/k8s/__fixture__/statefulset.json
+++ b/app/transform/k8s/__fixture__/statefulset.json
@@ -130,7 +130,8 @@
                         "resources": {
                             "requests": {
                                 "cpu": "3",
-                                "memory": "7Gi"
+                                "memory": "7Gi",
+                                "nvidia.com/gpu": 1
                             }
                         },
                         "securityContext": {},

--- a/app/transform/k8s/__fixture__/statefulset.jsonld
+++ b/app/transform/k8s/__fixture__/statefulset.jsonld
@@ -56,6 +56,21 @@
                             }
                         },
                         {
+                            "@id": "cluster:tenant1-pool-0.GPU.Allocated",
+                            "@type": "glc:SoftConstraint",
+                            "glc:hasDescription": "GPU.Allocated",
+                            "glc:maxValue": 1.0,
+                            "glc:hasAspect": {
+                                "@id": "glc:Performance"
+                            },
+                            "glc:hasID": {
+                                "@id": "cluster:tenant1-pool-0.GPU.Allocated"
+                            },
+                            "glc:measuredIn": {
+                                "@id": "glc:Core"
+                            }
+                        },
+                        {
                             "@id": "cluster:tenant1-pool-0.RAM.Allocated",
                             "@type": "glc:SoftConstraint",
                             "glc:hasDescription": "RAM.Allocated",

--- a/app/transform/k8s/__fixture__/statefulset.turtle
+++ b/app/transform/k8s/__fixture__/statefulset.turtle
@@ -4,7 +4,7 @@ cluster:tenant1 glc:hasID cluster:tenant1 .
 cluster:tenant1 glc:makes cluster:tenant1-pool-0 .
 cluster:tenant1-pool-0 rdf:type glc:AssignedTask .
 cluster:tenant1-pool-0 glc:hasDescription "StatefulSet" .
-cluster:tenant1-pool-0 glc:hasConstraint (cluster:tenant1-pool-0.CPU.Allocated cluster:tenant1-pool-0.RAM.Allocated) .
+cluster:tenant1-pool-0 glc:hasConstraint (cluster:tenant1-pool-0.CPU.Allocated cluster:tenant1-pool-0.GPU.Allocated cluster:tenant1-pool-0.RAM.Allocated) .
 cluster:tenant1-pool-0 glc:hasID cluster:tenant1-pool-0 .
 cluster:tenant1-pool-0.CPU.Allocated rdf:type glc:SoftConstraint .
 cluster:tenant1-pool-0.CPU.Allocated glc:hasDescription "CPU.Allocated" .
@@ -12,6 +12,12 @@ cluster:tenant1-pool-0.CPU.Allocated glc:maxValue 3.0^^<http://www.w3.org/2001/X
 cluster:tenant1-pool-0.CPU.Allocated glc:hasAspect glc:Performance .
 cluster:tenant1-pool-0.CPU.Allocated glc:hasID cluster:tenant1-pool-0.CPU.Allocated .
 cluster:tenant1-pool-0.CPU.Allocated glc:measuredIn glc:Core .
+cluster:tenant1-pool-0.GPU.Allocated rdf:type glc:SoftConstraint .
+cluster:tenant1-pool-0.GPU.Allocated glc:hasDescription "GPU.Allocated" .
+cluster:tenant1-pool-0.GPU.Allocated glc:maxValue 1.0^^<http://www.w3.org/2001/XMLSchema#integer> .
+cluster:tenant1-pool-0.GPU.Allocated glc:hasAspect glc:Performance .
+cluster:tenant1-pool-0.GPU.Allocated glc:hasID cluster:tenant1-pool-0.GPU.Allocated .
+cluster:tenant1-pool-0.GPU.Allocated glc:measuredIn glc:Core .
 cluster:tenant1-pool-0.RAM.Allocated rdf:type glc:SoftConstraint .
 cluster:tenant1-pool-0.RAM.Allocated glc:hasDescription "RAM.Allocated" .
 cluster:tenant1-pool-0.RAM.Allocated glc:maxValue 7516192768.0^^<http://www.w3.org/2001/XMLSchema#integer> .

--- a/app/transform/k8s/__fixture__/worker_node.json
+++ b/app/transform/k8s/__fixture__/worker_node.json
@@ -46,7 +46,8 @@
             "hugepages-1Gi": "0",
             "hugepages-2Mi": "0",
             "memory": "16283152Ki",
-            "pods": "110"
+            "pods": "110",
+            "nvidia.com/gpu": "1"
         },
         "capacity": {
             "cpu": "4",
@@ -54,7 +55,8 @@
             "hugepages-1Gi": "0",
             "hugepages-2Mi": "0",
             "memory": "16385552Ki",
-            "pods": "110"
+            "pods": "110",
+            "nvidia.com/gpu": "1"
         },
         "conditions": [
             {

--- a/app/transform/k8s/__fixture__/worker_node.jsonld
+++ b/app/transform/k8s/__fixture__/worker_node.jsonld
@@ -72,6 +72,22 @@
             "glc:hasDescription": "GPU",
             "glc:hasID": {
                 "@id": "cluster:glaciation-test-worker01.GPU"
+            },
+            "glc:hasMeasurement": {
+                "@id": "cluster:glaciation-test-worker01.GPU.Capacity.123",
+                "@type": "glc:Measurement",
+                "glc:hasDescription": "GPU.Capacity",
+                "glc:hasTimestamp": 123,
+                "glc:hasValue": 1,
+                "glc:hasID": {
+                    "@id": "cluster:glaciation-test-worker01.GPU.Capacity.123"
+                },
+                "glc:measuredIn": {
+                    "@id": "glc:Core"
+                },
+                "glc:relatesToMeasurementProperty": {
+                    "@id": "glc:GPU.Capacity"
+                }
             }
         },
         {
@@ -149,6 +165,24 @@
             "@type": "glc:MeasurementUnit",
             "glc:hasID": {
                 "@id": "glc:Core"
+            }
+        },
+        {
+            "@id": "glc:GPU.Capacity",
+            "@type": "glc:MeasurementProperty",
+            "glc:hasID": {
+                "@id": "glc:GPU.Capacity"
+            }
+        },
+        {
+            "@id": "glc:NVidiaPlugin",
+            "@type": "glc:MeasuringResource",
+            "glc:hasDescription": "NVidia Plugin https://github.com/NVIDIA/k8s-device-plugin",
+            "glc:hasID": {
+                "@id": "glc:NVidiaPlugin"
+            },
+            "glc:makes": {
+                "@id": "cluster:glaciation-test-worker01.GPU.Capacity.123"
             }
         },
         {

--- a/app/transform/k8s/__fixture__/worker_node.turtle
+++ b/app/transform/k8s/__fixture__/worker_node.turtle
@@ -17,6 +17,14 @@ cluster:glaciation-test-worker01.CPU.Capacity.123 glc:relatesToMeasurementProper
 cluster:glaciation-test-worker01.GPU rdf:type glc:WorkProducingResource .
 cluster:glaciation-test-worker01.GPU glc:hasDescription "GPU" .
 cluster:glaciation-test-worker01.GPU glc:hasID cluster:glaciation-test-worker01.GPU .
+cluster:glaciation-test-worker01.GPU glc:hasMeasurement cluster:glaciation-test-worker01.GPU.Capacity.123 .
+cluster:glaciation-test-worker01.GPU.Capacity.123 rdf:type glc:Measurement .
+cluster:glaciation-test-worker01.GPU.Capacity.123 glc:hasDescription "GPU.Capacity" .
+cluster:glaciation-test-worker01.GPU.Capacity.123 glc:hasTimestamp 123^^<http://www.w3.org/2001/XMLSchema#integer> .
+cluster:glaciation-test-worker01.GPU.Capacity.123 glc:hasValue 1^^<http://www.w3.org/2001/XMLSchema#integer> .
+cluster:glaciation-test-worker01.GPU.Capacity.123 glc:hasID cluster:glaciation-test-worker01.GPU.Capacity.123 .
+cluster:glaciation-test-worker01.GPU.Capacity.123 glc:measuredIn glc:Core .
+cluster:glaciation-test-worker01.GPU.Capacity.123 glc:relatesToMeasurementProperty glc:GPU.Capacity .
 cluster:glaciation-test-worker01.Network rdf:type glc:WorkProducingResource .
 cluster:glaciation-test-worker01.Network glc:hasDescription "Network" .
 cluster:glaciation-test-worker01.Network glc:hasID cluster:glaciation-test-worker01.Network .
@@ -52,6 +60,12 @@ glc:CPU.Capacity rdf:type glc:MeasurementProperty .
 glc:CPU.Capacity glc:hasID glc:CPU.Capacity .
 glc:Core rdf:type glc:MeasurementUnit .
 glc:Core glc:hasID glc:Core .
+glc:GPU.Capacity rdf:type glc:MeasurementProperty .
+glc:GPU.Capacity glc:hasID glc:GPU.Capacity .
+glc:NVidiaPlugin rdf:type glc:MeasuringResource .
+glc:NVidiaPlugin glc:hasDescription "NVidia Plugin https://github.com/NVIDIA/k8s-device-plugin" .
+glc:NVidiaPlugin glc:hasID glc:NVidiaPlugin .
+glc:NVidiaPlugin glc:makes cluster:glaciation-test-worker01.GPU.Capacity.123 .
 glc:RAM.Capacity rdf:type glc:MeasurementProperty .
 glc:RAM.Capacity glc:hasID glc:RAM.Capacity .
 glc:ResourceSpecification rdf:type glc:MeasuringResource .

--- a/app/transform/k8s/workload_transformer.py
+++ b/app/transform/k8s/workload_transformer.py
@@ -117,10 +117,21 @@ class WorkloadToRDFTransformer(TransformerBase, UpperOntologyBase):
                 [
                     "spec",
                     "template",
-                    "metadata",
-                    "annotations",
-                    "glaciation-project.eu/resource/requests/gpu",
-                ]  # noqa: E501
+                    "spec",
+                    "containers",
+                    "resources",
+                    "requests",
+                    "nvidia.com/gpu",
+                ],  # noqa: E501
+                [
+                    "spec",
+                    "template",
+                    "spec",
+                    "initContainers",
+                    "resources",
+                    "requests",
+                    "nvidia.com/gpu",
+                ],  # noqa: E501
             ],
             self.UNIT_CPU_CORE_ID,
             self.ASPECT_PERFORMANCE_ID,
@@ -136,7 +147,7 @@ class WorkloadToRDFTransformer(TransformerBase, UpperOntologyBase):
                     "template",
                     "metadata",
                     "annotations",
-                    "glaciation-project.eu/resource/requests/network",
+                    "glaciation-project.eu/network-allocated",
                 ]  # noqa: E501
             ],
             self.UNIT_BYTES_ID,
@@ -153,7 +164,7 @@ class WorkloadToRDFTransformer(TransformerBase, UpperOntologyBase):
                     "template",
                     "metadata",
                     "annotations",
-                    "glaciation-project.eu/resource/requests/energy",
+                    "glaciation-project.eu/energy-allocated",
                 ]  # noqa: E501
             ],
             self.UNIT_MILLIWATT_ID,
@@ -253,9 +264,11 @@ class WorkloadToRDFTransformer(TransformerBase, UpperOntologyBase):
                 [
                     "spec",
                     "template",
-                    "metadata",
-                    "annotations",
-                    "glaciation-project.eu/resource/limits/gpu",
+                    "spec",
+                    "containers",
+                    "resources",
+                    "limits",
+                    "nvidia.com/gpu",
                 ]  # noqa: E501
             ],
             self.UNIT_CPU_CORE_ID,
@@ -272,7 +285,7 @@ class WorkloadToRDFTransformer(TransformerBase, UpperOntologyBase):
                     "template",
                     "metadata",
                     "annotations",
-                    "glaciation-project.eu/resource/limits/network",
+                    "glaciation-project.eu/network-capacity",
                 ]  # noqa: E501
             ],
             self.UNIT_BYTES_ID,
@@ -289,7 +302,7 @@ class WorkloadToRDFTransformer(TransformerBase, UpperOntologyBase):
                     "template",
                     "metadata",
                     "annotations",
-                    "glaciation-project.eu/resource/limits/energy",
+                    "glaciation-project.eu/energy-capacity",
                 ]  # noqa: E501
             ],
             self.UNIT_MILLIWATT_ID,

--- a/app/transform/upper_ontology_base.py
+++ b/app/transform/upper_ontology_base.py
@@ -69,6 +69,7 @@ class UpperOntologyBase:
     )
     MEASURING_RESOURCE_NODE_CADVISOR_ID = IRI(GLACIATION_PREFIX, "cAdvisor")
     MEASURING_RESOURCE_NODE_ENERGY_BENCHMARK = IRI(GLACIATION_PREFIX, "EnergyBenchmark")
+    MEASURING_RESOURCE_NVIDIA_PLUGIN = IRI(GLACIATION_PREFIX, "NVidiaPlugin")
 
     MEASURING_RESOURCE_DESCRIPTIONS: Dict[IRI, str] = {
         MEASURING_RESOURCE_KEPLER_ID: "Kepler metrics https://sustainable-computing.io/",
@@ -76,6 +77,7 @@ class UpperOntologyBase:
         MEASURING_RESOURCE_NODE_K8S_SPEC_ID: "ResourceSpecification",
         MEASURING_RESOURCE_NODE_CADVISOR_ID: "cAdvisor metrics https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md",  # noqa: E501
         MEASURING_RESOURCE_NODE_ENERGY_BENCHMARK: "EnergyBenchmark",
+        MEASURING_RESOURCE_NVIDIA_PLUGIN: "NVidia Plugin https://github.com/NVIDIA/k8s-device-plugin",
     }
 
     # Units


### PR DESCRIPTION
Worker Nodes:
- adding GPU capacity NVidia k8s plugin specific
- node energy index annotation is fixed to be compatible with k8s API formats and requirements (`glaciation-project.eu/node-energy-index`)

Workloads:

Pods:
- adding GPU requests/limits NVidia k8s plugin specific
- Network and Energy requests/limits annotations fixed to be compatible with k8s API and requirements
-- `glaciation-project.eu/network-allocated`
-- `glaciation-project.eu/energy-allocated`
-- `glaciation-project.eu/network-capacity`
-- `glaciation-project.eu/energy-capacity`
